### PR TITLE
Fix error in dependabot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/sue445/gcp-kmsenv
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	cloud.google.com/go/kms v1.18.5
 	github.com/cockroachdb/errors v1.11.3


### PR DESCRIPTION
```
Dependabot can't resolve your Go dependency files
Dependabot failed to update your dependencies because there was an error resolving your Go dependency files.

Dependabot encountered the following error:

cmp: package cmp is not in GOROOT (/home/dependabot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.20.10.linux-amd64/src/cmp)
	slices: package slices is not in GOROOT (/home/dependabot/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.20.10.l
```

https://github.com/sue445/gcp-kmsenv/network/updates/871937279