### PR TITLE
ci: jandelgado/gcov2lcov-action is deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,17 +68,12 @@ jobs:
           INTEGRATION_TEST_WANT: "integration_test_value"
         continue-on-error: true # NOTE: secrets cannot be obtained with forked repository PR
 
-      - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1
-        with:
-          infile: coverage.out
-          outfile: coverage.lcov
-
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage.lcov
+          file: coverage.out
+          format: golang
         continue-on-error: true # NOTE: secrets cannot be obtained with forked repository PR
 
       - name: Slack Notification (not success)


### PR DESCRIPTION
ref. https://github.com/jandelgado/gcov2lcov-action/commit/9a62e299656d843ed3b0cb689bdef39af0aca654