### PR TITLE
checkout is unnecessary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-
       - uses: golang/govulncheck-action@v1
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
Removed checkout step from govulncheck workflow.