### PR TITLE
[CVE-2026-32280][CVE-2026-32281][CVE-2026-32283][CVE-2026-39836] Requires Go 1.25.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
           go-version-file: "go.mod"
+          go-version-input: ""
 
       - name: Slack Notification (not success)
         uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      # FIXME: Workaround for error during Go 1.25.11 downloading
+      - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
         with:
           go-version-file: "go.mod"
           go-version-input: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       matrix:
         golang:
-          - "1.25"
+          - "1.25.11"
           - "1.26"
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sue445/gcp-kmsenv
 
-go 1.25.0
+go 1.25.11
 
 require (
 	cloud.google.com/go/kms v1.31.0


### PR DESCRIPTION
* https://pkg.go.dev/vuln/GO-2026-5039 (CVE-2026-42507,  Severity unknown)
* https://pkg.go.dev/vuln/GO-2026-5037 (CVE-2026-27145,  Severity unknown)
* https://pkg.go.dev/vuln/GO-2026-4971 (CVE-2026-39836, Severity High)
* https://pkg.go.dev/vuln/GO-2026-4947 (CVE-2026-32280, Severity High)
* https://pkg.go.dev/vuln/GO-2026-4946 (CVE-2026-32281, Severity High)
* https://pkg.go.dev/vuln/GO-2026-4918 (CVE-2026-33814, Severity High)
* https://pkg.go.dev/vuln/GO-2026-4870 (CVE-2026-32283, Severity High)
* https://pkg.go.dev/vuln/GO-2026-4865 (CVE-2026-32289, Severity Moderate)

```
Run govulncheck -C . -format text ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.25.8
    Fixed in: net/textproto@go1.25.11
    Example traces found:
Error:       #1: kmsenv.go:9:2: gcp.init calls errors.init, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #2: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.25.8
    Fixed in: crypto/x509@go1.25.11
    Example traces found:
Error:       #1: mock_kmsenv/kms_client_mock.go:46:20: mock_kmsenv.MockKmsClient.Decrypt calls gomock.Controller.Call, which eventually calls x509.Certificate.Verify
Error:       #2: mock_kmsenv/kms_client_mock.go:46:20: mock_kmsenv.MockKmsClient.Decrypt calls gomock.Controller.Call, which eventually calls x509.Certificate.VerifyHostname
Error:       #3: kmsenv.go:60:24: gcp.KmsEnv.GetFromEnvOrKms calls fmt.Errorf, which eventually calls x509.HostnameError.Error

Vulnerability #3: GO-2026-4971
    Panic in Dial and LookupPort when handling NUL byte on Windows in net
  More info: https://pkg.go.dev/vuln/GO-2026-4971
  Standard library
    Found in: net@go1.25.8
    Fixed in: net@go1.25.10
    Example traces found:
Error:       #1: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls net.Dialer.Dial
Error:       #2: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls net.Dialer.DialContext
Error:       #3: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls net.Resolver.LookupHost

Vulnerability #4: GO-2026-4947
    Unexpected work during chain building in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4947
  Standard library
    Found in: crypto/x509@go1.25.8
    Fixed in: crypto/x509@go1.25.9
    Example traces found:
Error:       #1: mock_kmsenv/kms_client_mock.go:46:20: mock_kmsenv.MockKmsClient.Decrypt calls gomock.Controller.Call, which eventually calls x509.Certificate.Verify

Vulnerability #5: GO-2026-4946
    Inefficient policy validation in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4946
  Standard library
    Found in: crypto/x509@go1.25.8
    Fixed in: crypto/x509@go1.25.9
    Example traces found:
Error:       #1: mock_kmsenv/kms_client_mock.go:46:20: mock_kmsenv.MockKmsClient.Decrypt calls gomock.Controller.Call, which eventually calls x509.Certificate.Verify

Vulnerability #6: GO-2026-4918
    Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in
    net/http/internal/http2 in golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2026-4918
  Standard library
    Found in: net/http@go1.25.8
    Fixed in: net/http@go1.25.10
    Example traces found:
Error:       #1: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls http.Client.Do
Error:       #2: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls http.Client.PostForm

Vulnerability #7: GO-2026-4870
    Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection
    retention and DoS in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4870
  Standard library
    Found in: crypto/tls@go1.25.8
    Fixed in: crypto/tls@go1.25.9
    Example traces found:
Error:       #1: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls tls.Conn.Handshake
Error:       #2: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls tls.Conn.HandshakeContext
Error:       #3: kmsenv.go:9:2: gcp.init calls errors.init, which eventually calls tls.Conn.Read
Error:       #4: mock_kmsenv/kms_client_mock.go:46:20: mock_kmsenv.MockKmsClient.Decrypt calls gomock.Controller.Call, which eventually calls tls.Conn.Write
Error:       #5: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls tls.Dialer.DialContext

Vulnerability #8: GO-2026-4865
    JsBraceDepth Context Tracking Bugs (XSS) in html/template
  More info: https://pkg.go.dev/vuln/GO-2026-4865
  Standard library
    Found in: html/template@go1.25.8
    Fixed in: html/template@go1.25.9
    Example traces found:
Error:       #1: kmsenv.go:60:24: gcp.KmsEnv.GetFromEnvOrKms calls fmt.Errorf, which eventually calls template.Error.Error
Error:       #2: kmsenv.go:39:48: gcp.NewKmsEnv calls apiv1.NewKeyManagementClient, which eventually calls template.Template.Funcs
Error:       #3: kmsenv.go:4:2: gcp.init calls apiv1.init, which eventually calls template.Template.Parse
Error:       #4: kmsenv.go:60:24: gcp.KmsEnv.GetFromEnvOrKms calls fmt.Errorf, which eventually calls template.context.String

```

https://github.com/sue445/gcp-kmsenv/actions/runs/26891932225/job/79320092653